### PR TITLE
로그 필터링을 위한 long_query_time, long_query_length 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,30 @@ SQLLOG = {
     enabled=True
     sample_rate=1
     max_traceback_strlen=100
-    max_sql_strlen=
+    max_query_length=10000
+    long_query_time=1
+    long_query_length=10000
     ```
     * max_traceback_strlen
   
-      기본값은 `None`입니다(Key/Value가 존재하지 않거나 `max_traceback_strlen=`와 같이 설정). traceback 필드의 최대 문자 수를 결정합니다. 
+      기본값은 `None`입니다(Key/Value가 존재하지 않거나 `max_traceback_strlen=`와 같이 설정).  
+      traceback 필드의 최대 문자 수를 결정합니다. 
 
-    * max_sql_strlen
+    * max_query_length
 
-      기본값은 `None`입니다. sql 필드의 최대 문자 수를 결정합니다.
+      기본값은 10000입니다. sql 필드의 최대 문자 수를 결정합니다.  
+      값을 지정하지 않을 경우(No Value) 쿼리문 전체가 저장됩니다.
+
+    * long_query_time
+
+      단위는 초(sec)이고 기본값은 1입니다.  
+      값을 지정할 경우 해당 시간 이상으로 걸린 쿼리만 저장됩니다.
+
+    * long_query_length
+
+      기본값은 10000입니다.  
+      값을 지정할 경우 해당 길이 이상의 쿼리만 저장됩니다.  
+      단, INSERT, UPDATE 명령은 제외합니다.
 
 * Logstash로 직접 로깅할 경우 아래와 같이 설정합니다.
   ```bash

--- a/sqllog/__init__.py
+++ b/sqllog/__init__.py
@@ -33,17 +33,19 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
     else:
         should_log = True
 
-    # LONG_QUERY_TIME 기준으로 로그가 기록되어야 하는지 체크
+    # long_query_time 기준으로 로그가 기록되어야 하는지 체크
     if not should_log:
-        if cursor_wrapper.db.long_query_time and duration < cursor_wrapper.db.long_query_time:
-            should_log = False
+        if cursor_wrapper.db.long_query_time and \
+           duration >= cursor_wrapper.db.long_query_time:
+            should_log = True
 
     sql_strlen = len(sql)
 
-    # LONG_QUERY_LENGTH 기준으로 로그가 기록되어야 하는지 검사
+    # long_query_length 기준으로 로그가 기록되어야 하는지 검사
     if not should_log:
-        if cursor_wrapper.db.long_query_length and sql_strlen >= cursor_wrapper.db.long_query_length and command not in (
-        'insert', 'update'):
+        if cursor_wrapper.db.long_query_length and \
+           sql_strlen >= cursor_wrapper.db.long_query_length and \
+           command not in ('insert', 'update'):
             should_log = True
 
     if not should_log:

--- a/sqllog/__init__.py
+++ b/sqllog/__init__.py
@@ -24,23 +24,49 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
     sql = kwargs.get('sql')
     many = kwargs.get('many')
     duration = kwargs.get('duration')
+    command = sql.split(' ')[0].lower()
+
+    # LONG_QUERY_TIME / LONG_QUERY_LENGTH 설정 값 확인
+    # 하나라도 설정되어 있는 경우 조건에 맞을 때만 로그를 남김
+    # 하나도 설정된 것이 없는 경우 모든 로그 남김
+    # long_query_time = settings.SQLLOG.get('LONG_QUERY_TIME')
+    # long_query_length = settings.SQLLOG.get('LONG_QUERY_LENGTH')
+    if cursor_wrapper.db.long_query_time or cursor_wrapper.db.long_query_length:
+        should_log = False
+    else:
+        should_log = True
+
+    # LONG_QUERY_TIME 기준으로 로그가 기록되어야 하는지 체크
+    if not should_log:
+        if cursor_wrapper.db.long_query_time and duration < cursor_wrapper.db.long_query_time:
+            should_log = False
+
+    sql_strlen = len(sql)
+
+    # LONG_QUERY_LENGTH 기준으로 로그가 기록되어야 하는지 검사
+    if not should_log:
+        if cursor_wrapper.db.long_query_length and sql_strlen >= cursor_wrapper.db.long_query_length and command not in (
+        'insert', 'update'):
+            should_log = True
+
+    if not should_log:
+        return
 
     tbs = str(CallStack(
         lambda filename: not filename.startswith(THIS_MODULE_PATH) and filename.startswith(str(settings.BASE_DIR)),
     ))
+    tbs_strlen = len(tbs)
+    tbs = tbs[:cursor_wrapper.db.max_traceback_strlen]
 
     generalized_sql = fingerprint(sql)
     generalized_sql_hash = generalized_sql and md5(generalized_sql.encode()).hexdigest()
 
-    tbs_strlen = len(tbs)
-    tbs = tbs[:cursor_wrapper.db.max_traceback_strlen]
-
-    sql_strlen = len(sql)
-    sql = sql[:cursor_wrapper.db.max_sql_strlen]
+    limited_sql = sql[:cursor_wrapper.db.max_query_length]
 
     sqllog_logger.info(json.dumps(
         dict(
-            sql=sql,
+            command=command,
+            sql=limited_sql,
             many=many,
             alias=cursor_wrapper.db.alias,
             duration=duration,
@@ -55,7 +81,7 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
             traceback_strlen=tbs_strlen,
             is_truncated_traceback=tbs_strlen > len(tbs),
             sql_strlen=sql_strlen,
-            is_truncated_sql=sql_strlen > len(sql),
+            is_truncated_sql=sql_strlen > len(limited_sql),
         ),
         default=str,
     ))
@@ -65,7 +91,9 @@ def sqllog_env_file_change_handler(event, env):
     BaseDatabaseWrapper.force_debug_cursor = env['enabled']
     BaseDatabaseWrapper.sample_rate = env['sample_rate']
     BaseDatabaseWrapper.max_traceback_strlen = env['max_traceback_strlen']
-    BaseDatabaseWrapper.max_sql_strlen = env['max_sql_strlen']
+    BaseDatabaseWrapper.max_sql_strlen = env['max_query_length']
+    BaseDatabaseWrapper.long_query_time = env['long_query_time']
+    BaseDatabaseWrapper.long_query_length = env['long_query_length']
 
 
 if getattr(settings, 'SQLLOG', {}).get('ENABLED', False):

--- a/sqllog/__init__.py
+++ b/sqllog/__init__.py
@@ -122,5 +122,5 @@ if getattr(settings, 'SQLLOG', {}).get('ENABLED', False):
         sqllog_env_file_change_handler,
     )
     obser = Observer()
-    obser.schedule(handler, handler.obser_dir, recursive=True)
+    obser.schedule(handler, handler.obser_dir, recursive=False)
     obser.start()

--- a/sqllog/__init__.py
+++ b/sqllog/__init__.py
@@ -91,7 +91,7 @@ def sqllog_env_file_change_handler(event, env):
     BaseDatabaseWrapper.force_debug_cursor = env['enabled']
     BaseDatabaseWrapper.sample_rate = env['sample_rate']
     BaseDatabaseWrapper.max_traceback_strlen = env['max_traceback_strlen']
-    BaseDatabaseWrapper.max_sql_strlen = env['max_query_length']
+    BaseDatabaseWrapper.max_query_length = env['max_query_length']
     BaseDatabaseWrapper.long_query_time = env['long_query_time']
     BaseDatabaseWrapper.long_query_length = env['long_query_length']
 

--- a/sqllog/__init__.py
+++ b/sqllog/__init__.py
@@ -13,7 +13,6 @@ from watchdog.observers import Observer
 from .callstack import CallStack
 from .capture import exception, message
 from .handler import EnvFileEventHandler
-from .sql import fingerprint
 from .wrapper import BaseDatabaseWrapper, CursorDebugWrapper
 
 THIS_MODULE_PATH = os.path.dirname(__file__)
@@ -26,11 +25,9 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
     duration = kwargs.get('duration')
     command = sql.split(' ')[0].lower()
 
-    # LONG_QUERY_TIME / LONG_QUERY_LENGTH 설정 값 확인
+    # long_query_time / long_query_length 설정 값 확인
     # 하나라도 설정되어 있는 경우 조건에 맞을 때만 로그를 남김
     # 하나도 설정된 것이 없는 경우 모든 로그 남김
-    # long_query_time = settings.SQLLOG.get('LONG_QUERY_TIME')
-    # long_query_length = settings.SQLLOG.get('LONG_QUERY_LENGTH')
     if cursor_wrapper.db.long_query_time or cursor_wrapper.db.long_query_length:
         should_log = False
     else:
@@ -58,8 +55,11 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
     tbs_strlen = len(tbs)
     tbs = tbs[:cursor_wrapper.db.max_traceback_strlen]
 
-    generalized_sql = fingerprint(sql)
-    generalized_sql_hash = generalized_sql and md5(generalized_sql.encode()).hexdigest()
+    # NOTE: 트랜잭션 내의 쿼리 중 DB 데이터 락이 걸리는 경우 커밋이 로깅 과정 이후에 이루어지기 때문에
+    #       로깅 작업이 오래 걸릴 경우 DB 단에서 "Lock wait timeout"을 발생시킬 수 있음
+    #       따라서 로깅의 오버헤드를 최소화하여야 하고 SQL 문을 표준화하는 작업은 여기서 제외함
+    # generalized_sql = fingerprint(sql)
+    # generalized_sql_hash = generalized_sql and md5(generalized_sql.encode()).hexdigest()
 
     limited_sql = sql[:cursor_wrapper.db.max_query_length]
 
@@ -73,8 +73,8 @@ def sqllog_handler(cursor_wrapper, *args, **kwargs):
             config=settings.SQLLOG.get('CONFIG_NAME'),
             traceback=tbs,
             traceback_hash=md5(tbs.encode()).hexdigest(),
-            generalized_sql=generalized_sql,
-            generalized_sql_hash=generalized_sql_hash,
+            # generalized_sql=generalized_sql,
+            # generalized_sql_hash=generalized_sql_hash,
             pid=os.getpid(),
             tid=threading.get_ident(),
             native_tid=threading.get_native_id(),

--- a/sqllog/handler.py
+++ b/sqllog/handler.py
@@ -64,7 +64,7 @@ class EnvFileEventHandler(FileSystemEventHandler):
                 enabled=conf.get_value(bool, 'default', 'enabled', default=False),
                 sample_rate=conf.get_value(float, 'default', 'sample_rate', default=0),
                 max_traceback_strlen=conf.get_value(int, 'default', 'max_traceback_strlen', default=None),
-                max_sql_strlen=conf.get_value(int, 'default', 'max_query_length', default=10000),
+                max_query_length=conf.get_value(int, 'default', 'max_query_length', default=10000),
                 long_query_time=conf.get_value(int, 'default', 'long_query_time', default=1),
                 long_query_length=conf.get_value(int, 'default', 'long_query_length', default=10000),
             ))

--- a/sqllog/handler.py
+++ b/sqllog/handler.py
@@ -15,7 +15,9 @@ DEFAULT_ENV = dict(
     enabled=False,
     sample_rate=0,
     max_traceback_strlen=None,
-    max_sql_strlen=None,
+    max_query_length=10000,
+    long_query_time=1,
+    long_query_length=10000,
 )
 
 
@@ -62,7 +64,9 @@ class EnvFileEventHandler(FileSystemEventHandler):
                 enabled=conf.get_value(bool, 'default', 'enabled', default=False),
                 sample_rate=conf.get_value(float, 'default', 'sample_rate', default=0),
                 max_traceback_strlen=conf.get_value(int, 'default', 'max_traceback_strlen', default=None),
-                max_sql_strlen=conf.get_value(int, 'default', 'max_sql_strlen', default=None),
+                max_sql_strlen=conf.get_value(int, 'default', 'max_query_length', default=10000),
+                long_query_time=conf.get_value(int, 'default', 'long_query_time', default=1),
+                long_query_length=conf.get_value(int, 'default', 'long_query_length', default=10000),
             ))
         except Exception as e:
             # Reporting and disable logging when unknown exception raised.

--- a/tests/test.py
+++ b/tests/test.py
@@ -24,7 +24,7 @@ class DisableTests(SerializeTestCase):
         self.save_config(
             enabled=False,
             sample_rate=1,
-            max_sql_strlen=None,
+            max_query_length=None,
         )
 
         # Make SQL.
@@ -44,7 +44,7 @@ class EnableTests(SerializeTestCase):
         self.save_config(
             enabled=True,
             sample_rate=1,
-            max_sql_strlen=None,
+            max_query_length=None,
         )
 
         # Make SQL.
@@ -110,7 +110,7 @@ class SampleRateTests(SerializeTestCase):
         self.save_config(
             enabled=True,
             sample_rate=sample_rate,
-            max_sql_strlen=None,
+            max_query_length=None,
         )
 
         print(f'{query_count=},{sample_rate=}')
@@ -135,13 +135,13 @@ class SqlTests(SerializeTestCase):
     def test_sql_max_length_option(self):
         # Set configs.
         random.seed(time.time())
-        max_sql_strlen = random.randint(1, 20)
+        max_query_length = random.randint(1, 20)
 
         # Turn on logging
         self.save_config(
             enabled=True,
             sample_rate=1,
-            max_sql_strlen=max_sql_strlen,
+            max_query_length=max_query_length,
         )
 
         # Make SQL.
@@ -157,14 +157,14 @@ class SqlTests(SerializeTestCase):
 
         for log in logs:
             obj = json.loads(log.split(' ', 3)[-1])
-            assert len(obj['sql']) <= max_sql_strlen
+            assert len(obj['sql']) <= max_query_length
 
     def test_generalization(self):
         # Turn on logging
         self.save_config(
             enabled=True,
             sample_rate=1,
-            max_sql_strlen=None,
+            max_query_length=None,
         )
 
         # Make SQL.


### PR DESCRIPTION
- 로그 필터링을 위한 long_query_time, long_query_length 설정 추가
- generalized_sql, generalized_sql_hash 필드는 로깅에서 제외
- sqllog.ini 파일 경로의 하위 디렉토리에 대해서는 관찰하지 않음